### PR TITLE
Adding support for routing PagerDuty requests through egress proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and start using it!
 
 ## Configuration
 
-The plugin requires one configuration entry.
+The plugin only requires the 'service_key' configuration entry. There are two optional configurations if you send requests through an egress proxy.
 
 * service_key: This is the API Key to your service.
 
@@ -38,3 +38,11 @@ Or configure it at the instance level: $RDECK_BASE/etc/framework.properties
 
     framework.plugin.Notification.PagerDutyNotification.service_key=xx123049e89dd45f28ce35467a08577yz
 
+* proxy_host (optional): Your egress proxy host.
+* proxy_port: Required if proxy_host is set. The port the network egress proxy accepts traffic on.
+
+These can be configured at the project level. 
+Most likely this needs to be configured at the instance level: $RDECK_BASE/etc/framework.properties
+
+    framework.plugin.Notification.PagerDutyNotification.proxy_host=foo.example.net
+    framework.plugin.Notification.PagerDutyNotification.proxy_port=3128

--- a/src/PagerDutyNotification.groovy
+++ b/src/PagerDutyNotification.groovy
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode
 // See http://rundeck.org/docs/developer/notification-plugin-development.html
 
 // curl -H "Content-type: application/json" -X POST \
-//    -d '{    
+//    -d '{
 //      "service_key": "ee59049e89dd45f28ce35467a08577cb",
 //      "event_type": "trigger",
 //      "description": "FAILURE for production/HTTP on machine srv01.acme.com",
@@ -66,6 +66,13 @@ def triggerEvent(Map executionData, Map configuration) {
                     status: executionData.status,
             ]
     ]
+    if (configuration.proxy_host != null && configuration.proxy_port != null) {
+        System.err.println("DEBUG: proxy_host="+configuration.proxy_host)
+        System.err.println("DEBUG: proxy_port="+configuration.proxy_port)
+        System.getProperties().put("proxySet", "true")
+        System.getProperties().put("proxyHost", configuration.proxy_host)
+        System.getProperties().put("proxyPort", configuration.proxy_port)
+    }
 
     // Send the request.
     def url = new URL(DEFAULTS.PAGERDUTY_URL)
@@ -98,6 +105,10 @@ rundeckPlugin(NotificationPlugin){
         subject title:"Subject", description:"Incident subject line. Can contain \${job.status}, \${job.project}, \${job.name}, \${job.group}, \${job.user}, \${job.execid}", defaultValue:DEFAULTS.SUBJECT_LINE,required:true
 
         service_key title:"Service API Key", description:"The service key", scope:"Project"
+
+        proxy_host title:"Proxy host", description:"Outbound proxy", scope:"Project", defaultValue:null, required:false
+
+        proxy_port title:"Proxy port", description:"Outbound proxy port", scope:"Project", defaultValue:null, required:false
     }
     onstart { Map executionData,Map configuration ->
         triggerEvent(executionData, configuration)


### PR DESCRIPTION
'proxy_host' and 'proxy_port' are two optional parameters.
If they are set, PagerDutyNotification routes requests through a proxy.
Updated documentation.