### PR TITLE
Exclude libraries affected by CVEs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ dependencies {
     compile(group:'org.rundeck', name: 'rundeck-core', version: '2.8.2')
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
-    pluginLibs 'com.squareup.retrofit2:retrofit:2.3.0'
-    pluginLibs group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.2.0'
+    pluginLibs 'com.squareup.retrofit2:retrofit:2.6.1'
+    pluginLibs group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.6.1'
 
 
 }


### PR DESCRIPTION
This PR:
- Bumps unsecure retrofit version.