### PR TITLE
RUN-1783: Exclude gson from plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,12 @@ dependencies {
     compile(group:'org.rundeck', name: 'rundeck-core', version: '2.8.2')
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
-    pluginLibs 'com.squareup.retrofit2:retrofit:2.6.1'
-    pluginLibs group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.6.1'
+    pluginLibs 'com.squareup.retrofit2:retrofit:2.9.0'
 
+    compile "com.google.code.gson:gson:2.8.9"
+    pluginLibs (group: 'com.squareup.retrofit2', name: 'converter-gson', version: "2.9.0") {
+        exclude group: 'com.google.code.gson', module: 'gson'
+    }
 
 }
 


### PR DESCRIPTION
upgrade retrofit and gson version