### PR TITLE
RUN-3086: Pin the okhttp version to 4.12.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
       - name: Upload git-plugin jar
-        uses: actions/upload-artifact@v1.0.0
+        uses: actions/upload-artifact@v4
         with:
           # Artifact name
           name: git-resource-model-${{ steps.get_version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -29,18 +29,22 @@ and start using it!
 
 ## Configuration
 
-The plugin only requires the 'service_key' configuration entry. There are two optional configurations if you send requests through an egress proxy.
+The plugin only requires the `service_key`  and `version` configuration entries. 
+There are two optional configurations if you send requests through an egress proxy.
 
 * service_key: This is the API Key to your service.
+* version: PagerDuty API Version: v1 or v2.
 
 Configure the service_key in your project configuration by
 adding an entry like so: $RDECK_BASE/projects/{project}/etc/project.properties
 
     project.plugin.Notification.PagerDutyNotification.service_key=xx123049e89dd45f28ce35467a08577yz
+    project.plugin.Notification.PagerDutyNotification.version=v2
 
 Or configure it at the instance level: $RDECK_BASE/etc/framework.properties
 
     framework.plugin.Notification.PagerDutyNotification.service_key=xx123049e89dd45f28ce35467a08577yz
+    framework.plugin.Notification.PagerDutyNotification.version=v2
 
 * proxy_host (optional): Your egress proxy host.
 * proxy_port: Required if proxy_host is set. The port the network egress proxy accepts traffic on.

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,6 @@ scmVersion {
 
 project.version = scmVersion.version
 
-
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin
     pluginLibs
@@ -67,10 +66,15 @@ dependencies {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
 
+    constraints {
+        // Pins the version to avoid  a dependency on okhttp 3.14.9 that suffers from the CVE.
+        // This version of okhttp is inline with the one used in Rundeck 5.9.x
+        pluginLibs('com.squareup.okhttp3:okhttp:4.12.0') {
+            because "CVE-2023-3635"
+        }
+    }
+
 }
-
-
-
 
 // task to copy plugin libs to output/lib dir
 task copyToLib(type: Copy) {

--- a/src/main/groovy/com/rundeck/plugins/PagerDutyNotificationPlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/PagerDutyNotificationPlugin.groovy
@@ -21,7 +21,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by luistoledo on 6/28/17.
  */
 @Plugin(service="Notification", name="PagerDutyNotification")
-@PluginDescription(title="PagerDuty", description="")
+@PluginDescription(title="PagerDuty Notification via the Events API", description="Legacy PagerDuty Notification Plugin")
 public class PagerDutyNotificationPlugin implements NotificationPlugin {
 
     final static String PAGERDUTY_URL = "https://events.pagerduty.com"

--- a/src/main/groovy/com/rundeck/plugins/PagerDutyNotificationPlugin.groovy
+++ b/src/main/groovy/com/rundeck/plugins/PagerDutyNotificationPlugin.groovy
@@ -21,7 +21,7 @@ import retrofit2.converter.gson.GsonConverterFactory;
  * Created by luistoledo on 6/28/17.
  */
 @Plugin(service="Notification", name="PagerDutyNotification")
-@PluginDescription(title="PagerDuty Notification via the Events API", description="Legacy PagerDuty Notification Plugin")
+@PluginDescription(title="PagerDuty Notification", description="Legacy PagerDuty Notification via Events API Plugin")
 public class PagerDutyNotificationPlugin implements NotificationPlugin {
 
     final static String PAGERDUTY_URL = "https://events.pagerduty.com"


### PR DESCRIPTION
Jira ticket: [RUN-3086](https://pagerduty.atlassian.net/browse/RUN-3086?atlOrigin=eyJpIjoiMmM1NWYyYTNkMzRkNDI5MWJjYTNlMTNmODZjNGM4YTQiLCJwIjoiaiJ9)

- Pin the okhttp version to 4.12.0
- Update the version of github actions actions/upload-artifact
- Update the plugin title and description

*Testing*
**Tested with Rundeck v5.9.0**
- A Job configured to Notify PD via the events API V2:
![Screenshot 2025-02-20 at 11 38 41 AM](https://github.com/user-attachments/assets/83e21126-ce39-4c25-95fd-a6abbc02f869)
- An incident created in PD
![Screenshot 2025-02-20 at 11 37 51 AM](https://github.com/user-attachments/assets/8a81b27c-e494-4931-9b1c-dc763a1c42c1)

