### PR TITLE
Grails 7 Migration - Rundeck 6.0 Compatibility

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Get Fetch Tags
         run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
         if: ${{ !contains(github.ref, 'refs/tags') }}
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-        distribution: 'temurin'
+          distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'temurin'
+        distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: '17'
           distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-        distribution: 'temurin'
+          distribution: 'zulu'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'temurin'
+        distribution: 'temurin'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,16 @@
 on:
   push:
-    # Sequence of patterns matched against refs/tags
     tags:
-      - '*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - '*.*.*'
 
-name: Create Release
+name: Publish Release
 
 permissions:
   contents: write
 
 jobs:
   release:
-    name: Create Release
+    name: Publish Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -37,6 +36,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create ${{ github.ref_name }} \
+            --generate-notes \
             --title "Release ${{ steps.get_version.outputs.VERSION }}" \
-            --notes "Release ${{ steps.get_version.outputs.VERSION }}" \
             build/libs/pagerduty-notification-${{ steps.get_version.outputs.VERSION }}.jar
+      - name: Publish to Maven Central
+        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+        env:
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -74,10 +74,10 @@ repositories {
 dependencies {
 
     implementation 'org.apache.groovy:groovy-all:4.0.29'
-    compileOnly(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-SNAPSHOT') {
+    compileOnly(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-alpha1-20260407') {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
-    testImplementation(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-SNAPSHOT') {
+    testImplementation(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-alpha1-20260407') {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
     // Add secure replacement for excluded commons-lang

--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,11 @@ plugins {
     id 'pl.allegro.tech.build.axion-release' version '1.18.17'
 }
 
-group = 'com.rundeck.plugin'
+group = 'com.github.rundeck-plugins'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -37,6 +37,9 @@ scmVersion {
 
 project.version = scmVersion.version
 
+// Override version for Grails 7 upgrade
+project.version = '1.3.3-grails7-upgrade-test'
+
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin
     pluginLibs
@@ -49,13 +52,14 @@ configurations{
 
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
 dependencies {
 
-    implementation 'org.apache.groovy:groovy-all:4.0.22'
-    implementation(group:'org.rundeck', name: 'rundeck-core', version: '5.15.0-20250902') {
+    implementation 'org.apache.groovy:groovy-all:4.0.29'
+    implementation(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-SNAPSHOT') {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
     // Add secure replacement for excluded commons-lang
@@ -108,3 +112,25 @@ jar {
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
 
+test {
+    useJUnitPlatform()
+    
+    // Java 17+ module access
+    jvmArgs = [
+        '--add-opens=java.base/java.lang=ALL-UNNAMED',
+        '--add-opens=java.base/java.util=ALL-UNNAMED',
+        '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED'
+    ]
+}
+
+apply plugin: 'maven-publish'
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.github.rundeck-plugins'
+            artifactId = 'pagerduty-notification'
+            from components.java
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ java {
 }
 
 // Override version for Grails 7 upgrade
-project.version = '1.3.4-grails7-upgrade-test'
+project.version = '1.3.5-grails7-upgrade-test'
 
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin

--- a/build.gradle
+++ b/build.gradle
@@ -19,24 +19,6 @@ java {
     }
 }
 
-scmVersion {
-    ignoreUncommittedChanges = true
-    tag {
-        prefix = ''
-        versionSeparator = ''
-        deserializer { config, position, tagName ->
-            def orig = tagName
-            //append .0 to satisfy semver if the tag version is only X.Y
-            if (orig.split('\\.').length < 3) {
-                orig += ".0"
-            }
-            orig
-        }
-    }
-}
-
-project.version = scmVersion.version
-
 // Override version for Grails 7 upgrade
 project.version = '1.3.3-grails7-upgrade-test'
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ java {
 }
 
 // Override version for Grails 7 upgrade
-project.version = '1.3.5-grails7-upgrade-test'
+project.version = '1.3.6-grails7-upgrade-test'
 
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin
@@ -61,7 +61,7 @@ dependencies {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
     // Add secure replacement for excluded commons-lang
-    implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
 
     pluginLibs 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ configurations{
 
 repositories {
     mavenLocal()
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        
+        // Only search this repository for org.rundeck snapshots
+        content {
+            includeGroup('org.rundeck')
+        }
+    }
     mavenCentral()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ java {
 }
 
 // Override version for Grails 7 upgrade
-project.version = '1.3.3-grails7-upgrade-test'
+project.version = '1.3.4-grails7-upgrade-test'
 
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,16 @@ plugins {
     id 'groovy'
     id 'java'
     id 'pl.allegro.tech.build.axion-release' version '1.18.17'
-    id 'maven-publish'
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
-group = 'com.rundeck.plugins'
+group = 'org.rundeck.plugins'
+
+ext.publishName = "PagerDuty Notification ${project.version}"
+ext.githubSlug = 'rundeck-plugins/pagerduty-notification'
+ext.developers = [
+        [id: 'gschueler', name: 'Greg Schueler', email: 'greg@rundeck.com']
+]
 
 scmVersion {
     ignoreUncommittedChanges = false
@@ -27,6 +33,8 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+    withSourcesJar()
+    withJavadocJar()
 }
 
 version = scmVersion.version  // Dynamic version from git tag
@@ -66,7 +74,10 @@ repositories {
 dependencies {
 
     implementation 'org.apache.groovy:groovy-all:4.0.29'
-    implementation(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-SNAPSHOT') {
+    compileOnly(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-SNAPSHOT') {
+        exclude group: 'commons-lang', module: 'commons-lang'
+    }
+    testImplementation(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-SNAPSHOT') {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
     // Add secure replacement for excluded commons-lang
@@ -130,27 +141,14 @@ test {
     ]
 }
 
-publishing {
-    publications {
-        maven(MavenPublication) {
-            groupId = 'com.rundeck.plugins'
-            artifactId = 'pagerduty-notification'
-            version = project.version
-            from components.java
-        }
-    }
-    
+nexusPublishing {
+    packageGroup = 'org.rundeck.plugins'
     repositories {
-        maven {
-            name = "PackageCloudTest"
-            url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
-            authentication {
-                header(HttpHeaderAuthentication)
-            }
-            credentials(HttpHeaderCredentials) {
-                name = "Authorization"
-                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
-            }
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }
+
+apply from: "${rootDir}/gradle/publishing.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
     // Add secure replacement for excluded commons-lang
-    implementation 'org.apache.commons:commons-lang3:3.17.0'
+    implementation 'org.apache.commons:commons-lang3:3.20.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
 
     pluginLibs 'com.squareup.retrofit2:retrofit:2.9.0'

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,13 @@ repositories {
     maven {
         name = 'Central Portal Snapshots'
         url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        content {
+            includeGroup('org.rundeck')
+        }
+    }
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
         
         // Only search this repository for org.rundeck snapshots
         content {

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,19 @@ plugins {
     id 'groovy'
     id 'java'
     id 'pl.allegro.tech.build.axion-release' version '1.18.17'
+    id 'maven-publish'
 }
 
-group = 'com.github.rundeck-plugins'
+group = 'com.rundeck.plugins'
+
+scmVersion {
+    ignoreUncommittedChanges = false
+    tag {
+        prefix = ''           // NO "v" prefix - see PLUGIN_TAGGING_ARCHITECTURE.md
+        versionSeparator = ''
+    }
+    versionCreator 'simple'  // Use simple version creator (just tag name)
+}
 
 java {
     toolchain {
@@ -19,8 +29,7 @@ java {
     }
 }
 
-// Override version for Grails 7 upgrade
-project.version = '1.3.6-grails7-upgrade-test'
+version = scmVersion.version  // Dynamic version from git tag
 
 configurations{
     //declare custom pluginLibs configuration to include only libs for this plugin
@@ -121,14 +130,27 @@ test {
     ]
 }
 
-apply plugin: 'maven-publish'
-
 publishing {
     publications {
         maven(MavenPublication) {
-            groupId = 'com.github.rundeck-plugins'
+            groupId = 'com.rundeck.plugins'
             artifactId = 'pagerduty-notification'
+            version = project.version
             from components.java
+        }
+    }
+    
+    repositories {
+        maven {
+            name = "PackageCloudTest"
+            url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
+            }
         }
     }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,86 @@
+/**
+ * Define project extension values in the project gradle file before including this file:
+ *
+ * publishName = 'Name of Package'
+ * publishDescription = 'description' (optional)
+ * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
+ * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
+ *
+ * Define project properties to sign and publish when invoking publish task:
+ *
+ *     ./gradlew \
+ *     -PsigningKey="base64 encoded gpg key" \
+ *     -PsigningPassword="password for key" \
+ *     -PsonatypeUsername="sonatype token user" \
+ *     -PsonatypePassword="sonatype token password" \
+ *     publishToSonatype closeAndReleaseSonatypeStagingRepository
+ */
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+    publications {
+        "${project.name}"(MavenPublication) { publication ->
+            from components.java
+
+            pom {
+                name = publishName
+                description = project.ext.hasProperty('publishDescription') ? project.ext.publishDescription :
+                        project.description ?: publishName
+                url = "https://github.com/${githubSlug}"
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${githubSlug}"
+                    connection = "scm:git:git@github.com/${githubSlug}.git"
+                    developerConnection = "scm:git:git@github.com:${githubSlug}.git"
+                }
+                if (project.ext.developers) {
+                    developers {
+                        project.ext.developers.each { dev ->
+                            developer {
+                                id = dev.id
+                                name = dev.name
+                                email = dev.email
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+    repositories {
+        def pkgcldWriteToken = System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken")
+        if (pkgcldWriteToken) {
+            maven {
+                name = "PackageCloudTest"
+                url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
+                authentication {
+                    header(HttpHeaderAuthentication)
+                }
+                credentials(HttpHeaderCredentials) {
+                    name = "Authorization"
+                    value = "Bearer " + pkgcldWriteToken
+                }
+            }
+        }
+    }
+}
+def base64Decode = { String prop ->
+    project.findProperty(prop) ?
+            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
+            null
+}
+
+if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
+    signing {
+        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
+        sign(publishing.publications)
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,0 @@
-jdk:
-  - openjdk17


### PR DESCRIPTION
## Overview
Updates this plugin for Grails 7 / Rundeck 6.0 compatibility.

## Key Changes
- Upgraded to Java 17
- Updated to Grails 7 / Groovy 4 / Spring Boot 3
- Standardized Gradle to 8.14.3
- Updated version to 1.3.7-grails7 format

## Documentation
Migration details and handoff documentation: [.github/Grails7-Handoff/](https://github.com/rundeck-plugins/.github/tree/grails7-upgrade/Grails7-Handoff)

## Testing
- Plugin builds and tests successfully with Java 17
- Compatible with Rundeck 6.0 (Grails 7)

## Notes
- Version uses temporary `-grails7` suffix (will be removed at release)
- Maintains backward compatibility with Rundeck 5.x