### PR TITLE
RUN-4569 Mitigate Jackson CVE-2026-54512/54513

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 plugins {
     id 'groovy'
     id 'java'
-    id 'pl.allegro.tech.build.axion-release' version '1.18.17'
+    id 'pl.allegro.tech.build.axion-release' version '1.21.2'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
@@ -74,10 +74,10 @@ repositories {
 dependencies {
 
     implementation 'org.apache.groovy:groovy-all:4.0.29'
-    compileOnly(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-alpha1-20260407') {
+    compileOnly(group:'org.rundeck', name: 'rundeck-core', version: '6.1.0-SNAPSHOT') {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
-    testImplementation(group:'org.rundeck', name: 'rundeck-core', version: '6.0.0-alpha1-20260407') {
+    testImplementation(group:'org.rundeck', name: 'rundeck-core', version: '6.1.0-SNAPSHOT') {
         exclude group: 'commons-lang', module: 'commons-lang'
     }
     // Add secure replacement for excluded commons-lang


### PR DESCRIPTION
## Summary
- Bump `rundeck-core` to `6.1.0-SNAPSHOT`, which pulls patched `jackson-databind` 2.22.0 transitively, mitigating CVE-2026-54512 / CVE-2026-54513.
- Standardize the axion-release plugin to 1.21.2.

## Test plan
- [x] `rundeck-core:6.1.0-SNAPSHOT` and `jackson-databind:2.22.0` resolve on compileClasspath (verified locally).
- [ ] CI build and Snyk scan pass on the branch.