### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     name: Publish Release
     runs-on: ubuntu-latest
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -39,10 +41,38 @@ jobs:
             --generate-notes \
             --title "Release ${{ steps.get_version.outputs.VERSION }}" \
             build/libs/pagerduty-notification-${{ steps.get_version.outputs.VERSION }}.jar
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: |
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/pagerduty-notification/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/pagerduty-notification-${VERSION}.jar" "pagerduty-notification-${VERSION}.jar"
+          sign_and_upload "build/libs/pagerduty-notification-${VERSION}-sources.jar" "pagerduty-notification-${VERSION}-sources.jar"
+          sign_and_upload "build/libs/pagerduty-notification-${VERSION}-javadoc.jar" "pagerduty-notification-${VERSION}-javadoc.jar"
+          sign_and_upload "build/publications/pagerduty-notification/pom-default.xml" "pagerduty-notification-${VERSION}.pom"
+        env:
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ plugins {
     id 'groovy'
     id 'java'
     id 'pl.allegro.tech.build.axion-release' version '1.21.2'
-    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
 }
 
 group = 'org.rundeck.plugins'
@@ -139,16 +138,6 @@ test {
         '--add-opens=java.base/java.util=ALL-UNNAMED',
         '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED'
     ]
-}
-
-nexusPublishing {
-    packageGroup = 'org.rundeck.plugins'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
 }
 
 apply from: "${rootDir}/gradle/publishing.gradle"

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -5,18 +5,10 @@
  * publishDescription = 'description' (optional)
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
- *
- * Define project properties to sign and publish when invoking publish task:
- *
- *     ./gradlew \
- *     -PsigningKey="base64 encoded gpg key" \
- *     -PsigningPassword="password for key" \
- *     -PsonatypeUsername="sonatype token user" \
- *     -PsonatypePassword="sonatype token password" \
- *     publishToSonatype closeAndReleaseSonatypeStagingRepository
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
+
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
 
 publishing {
     publications {
@@ -56,31 +48,16 @@ publishing {
         }
     }
     repositories {
-        def pkgcldWriteToken = System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken")
-        if (pkgcldWriteToken) {
-            maven {
-                name = "PackageCloudTest"
-                url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = "Bearer " + pkgcldWriteToken
-                }
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
             }
         }
-    }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira ticket

[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Description

Migrate `pagerduty-notification` publishing from Maven Central (Sonatype) to PackageCloud, applying the same design already validated on [rundeck-plugins/sshj-plugin#136](https://github.com/rundeck-plugins/sshj-plugin/pull/136) and the other already-migrated `rundeck-plugins` repos. Part of the RUN-4570 Maven Central publishing limits resolution — plugins account for the bulk of the file/release count on Maven Central, but no external project depends on them as Maven dependencies.

- Removed `nexusPublish`/`nexusPublishing`.
- Point the PackageCloud maven repo at the configurable `PKGCLD_REPO_URL` env var (with a fallback to the real `rundeck-plugins` repo), dropping the now-unnecessary guard.
- Dropped Gradle-side GPG signing (`sign(publishing.publications)`): PackageCloud's Maven endpoint rejects the checksum Gradle auto-generates for `.asc` signature files (422 Unprocessable Entity). Sign and upload via `gpg` CLI + `curl` instead, directly in `release.yml` — the same mechanism validated end-to-end on `sshj-plugin`.
- `release.yml`: replaced the "Publish to Maven Central" step with "Publish to PackageCloud" + a "Sign and upload GPG signatures" step.

## Testing instructions

- Merge this PR.
- Tag a version to trigger the release workflow.
- Verify the artifact and its `.asc` signature land under `org/rundeck/plugins/pagerduty-notification/<version>/` on PackageCloud.
- Verify `./gradlew build` still succeeds without `PKGCLD_REPO_URL` set.
